### PR TITLE
Add GravGunPickupAllowed hook

### DIFF
--- a/lua/entities/emplacements_turret_base/init.lua
+++ b/lua/entities/emplacements_turret_base/init.lua
@@ -146,3 +146,7 @@ function ENT:PhysicsSimulate( phys, deltatime )
     self.ShadowParams.deltatime = deltatime
     phys:ComputeShadowControl( self.ShadowParams )
 end
+
+function ENT:GravGunPickupAllowed()
+    return false
+end


### PR DESCRIPTION
This *should* fix a small issue where players are able to gravgun the turret itself, they should only be able to physgun the turrebase to move it around