### PR TITLE
Rebalance/tweaks

### DIFF
--- a/lua/effects/gdca_airburst_t/init.lua
+++ b/lua/effects/gdca_airburst_t/init.lua
@@ -9,7 +9,7 @@ function EFFECT:Init( data )
     self.Emitter = ParticleEmitter( self.Origin )
     sound.Play( "ambient/explosions/explode_" .. math.random( 1, 4 ) .. ".wav", self.Origin, 75, 100, 1 )
 
-    for i = 0, 40 * self.Scale do
+    for _ = 0, 40 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Origin )
 
         if ( Smoke ) then
@@ -26,7 +26,7 @@ function EFFECT:Init( data )
         end
     end
 
-    for i = 0, 40 * self.Scale do
+    for _ = 0, 40 * self.Scale do
         local Shrapnel = self.Emitter:Add( "effects/fleck_cement" .. math.random( 1, 2 ), self.Origin )
 
         if ( Shrapnel ) then
@@ -43,7 +43,7 @@ function EFFECT:Init( data )
         end
     end
 
-    for i = 1, 3 do
+    for _ = 1, 3 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Origin )
 
         if ( Flash ) then
@@ -60,7 +60,7 @@ function EFFECT:Init( data )
         end
     end
 
-    for i = 1, 1 do
+    for _ = 1, 1 do
         local Shockwave = self.Emitter:Add( "sprites/heatwave", self.Origin )
 
         if ( Shockwave ) then

--- a/lua/effects/gdca_cinematicboom_t/init old light.lua
+++ b/lua/effects/gdca_cinematicboom_t/init old light.lua
@@ -24,14 +24,6 @@ local mats = {
     [ MAT_GLASS ] = { 4, 7 },
 }
 
-local sounds = {
-    [ 1 ] = { "Bullet.Dirt", },
-    [ 2 ] = { "Bullet.Concrete", },
-    [ 3 ] = { "Bullet.Metal", },
-    [ 4 ] = { "Bullet.Glass", },
-    [ 5 ] = { "Bullet.Flesh", },
-}
-
 function EFFECT:Init( data )
     self.Entity = data:GetEntity() -- Entity determines what is creating the dynamic light			//
     self.Pos = data:GetOrigin() -- Origin determines the global position of the effect			//
@@ -91,7 +83,7 @@ function EFFECT:Init( data )
 end
 
 function EFFECT:Dust()
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -108,7 +100,7 @@ function EFFECT:Dust()
         end
     end
 
-    for i = 1, 20 * self.Scale do
+    for _ = 1, 20 * self.Scale do
         local Dust = self.Emitter:Add( "particle/particle_composite", self.Pos )
 
         if ( Dust ) then
@@ -116,8 +108,8 @@ function EFFECT:Dust()
             Dust:SetDieTime( math.Rand( 2, 3 ) )
             Dust:SetStartAlpha( 230 )
             Dust:SetEndAlpha( 0 )
-            Dust:SetStartSize( ( 50 * self.Scale ) )
-            Dust:SetEndSize( ( 100 * self.Scale ) )
+            Dust:SetStartSize( 50 * self.Scale )
+            Dust:SetEndSize( 100 * self.Scale )
             Dust:SetRoll( math.Rand( 150, 360 ) )
             Dust:SetRollDelta( math.Rand( -1, 1 ) )
             Dust:SetAirResistance( 150 )
@@ -126,7 +118,7 @@ function EFFECT:Dust()
         end
     end
 
-    for i = 1, 15 * self.Scale do
+    for _ = 1, 15 * self.Scale do
         local Dust = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Dust ) then
@@ -134,8 +126,8 @@ function EFFECT:Dust()
             Dust:SetDieTime( math.Rand( 1, 5 ) * self.Scale )
             Dust:SetStartAlpha( 50 )
             Dust:SetEndAlpha( 0 )
-            Dust:SetStartSize( ( 80 * self.Scale ) )
-            Dust:SetEndSize( ( 100 * self.Scale ) )
+            Dust:SetStartSize( 80 * self.Scale )
+            Dust:SetEndSize( 100 * self.Scale )
             Dust:SetRoll( math.Rand( 150, 360 ) )
             Dust:SetRollDelta( math.Rand( -1, 1 ) )
             Dust:SetAirResistance( 250 )
@@ -144,7 +136,7 @@ function EFFECT:Dust()
         end
     end
 
-    for i = 1, 25 * self.Scale do
+    for _ = 1, 25 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_cement" .. math.random( 1, 2 ), self.Pos )
 
         if ( Debris ) then
@@ -164,8 +156,8 @@ function EFFECT:Dust()
     local Angle = self.DirVec:Angle()
 
     --/ This part makes the trailers ///
-    for i = 1, self.DebrizzlemyNizzle do
-        Angle:RotateAroundAxis( Angle:Forward(), ( 360 / self.DebrizzlemyNizzle ) )
+    for _ = 1, self.DebrizzlemyNizzle do
+        Angle:RotateAroundAxis( Angle:Forward(), 360 / self.DebrizzlemyNizzle )
         local DustRing = Angle:Up()
         local RanVec = self.DirVec * math.Rand( 1, 5 ) + ( DustRing * math.Rand( 2, 5 ) )
 
@@ -188,7 +180,7 @@ function EFFECT:Dust()
 end
 
 function EFFECT:Dirt()
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -205,7 +197,7 @@ function EFFECT:Dirt()
         end
     end
 
-    for i = 1, 20 * self.Scale do
+    for _ = 1, 20 * self.Scale do
         local Dust = self.Emitter:Add( "particle/particle_composite", self.Pos )
 
         if ( Dust ) then
@@ -213,8 +205,8 @@ function EFFECT:Dirt()
             Dust:SetDieTime( math.Rand( 2, 3 ) )
             Dust:SetStartAlpha( 230 )
             Dust:SetEndAlpha( 0 )
-            Dust:SetStartSize( ( 50 * self.Scale ) )
-            Dust:SetEndSize( ( 100 * self.Scale ) )
+            Dust:SetStartSize( 50 * self.Scale )
+            Dust:SetEndSize( 100 * self.Scale )
             Dust:SetRoll( math.Rand( 150, 360 ) )
             Dust:SetRollDelta( math.Rand( -1, 1 ) )
             Dust:SetAirResistance( 150 )
@@ -223,7 +215,7 @@ function EFFECT:Dirt()
         end
     end
 
-    for i = 1, 15 * self.Scale do
+    for _ = 1, 15 * self.Scale do
         local Dust = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Dust ) then
@@ -231,8 +223,8 @@ function EFFECT:Dirt()
             Dust:SetDieTime( math.Rand( 1, 5 ) * self.Scale )
             Dust:SetStartAlpha( 50 )
             Dust:SetEndAlpha( 0 )
-            Dust:SetStartSize( ( 80 * self.Scale ) )
-            Dust:SetEndSize( ( 100 * self.Scale ) )
+            Dust:SetStartSize( 80 * self.Scale )
+            Dust:SetEndSize( 100 * self.Scale )
             Dust:SetRoll( math.Rand( 150, 360 ) )
             Dust:SetRollDelta( math.Rand( -1, 1 ) )
             Dust:SetAirResistance( 250 )
@@ -241,7 +233,7 @@ function EFFECT:Dirt()
         end
     end
 
-    for i = 1, 25 * self.Scale do
+    for _ = 1, 25 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_cement" .. math.random( 1, 2 ), self.Pos )
 
         if ( Debris ) then
@@ -261,8 +253,8 @@ function EFFECT:Dirt()
     local Angle = self.DirVec:Angle()
 
     --/ This part makes the trailers ///
-    for i = 1, self.DebrizzlemyNizzle do
-        Angle:RotateAroundAxis( Angle:Forward(), ( 360 / self.DebrizzlemyNizzle ) )
+    for _ = 1, self.DebrizzlemyNizzle do
+        Angle:RotateAroundAxis( Angle:Forward(), 360 / self.DebrizzlemyNizzle )
         local DustRing = Angle:Up()
         local RanVec = self.DirVec * math.Rand( 2, 6 ) + ( DustRing * math.Rand( 1, 4 ) )
 
@@ -286,7 +278,7 @@ end
 
 function EFFECT:Sand()
     -- This is the main plume
-    for i = 0, 45 * self.Scale do
+    for _ = 0, 45 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Smoke ) then
@@ -305,7 +297,7 @@ function EFFECT:Sand()
     end
 
     -- This is the dirt kickup
-    for i = 0, 20 * self.Scale do
+    for _ = 0, 20 * self.Scale do
         local Dust = self.Emitter:Add( "particle/particle_composite", self.Pos )
 
         if ( Dust ) then
@@ -324,7 +316,7 @@ function EFFECT:Sand()
     end
 
     -- Chunkage
-    for i = 0, 25 * self.Scale do
+    for _ = 0, 25 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_cement" .. math.random( 1, 2 ), self.Pos )
 
         if ( Debris ) then
@@ -342,7 +334,7 @@ function EFFECT:Sand()
     end
 
     -- Shrapnel
-    for i = 0, 25 * self.Scale do
+    for _ = 0, 25 * self.Scale do
         local Shrapnel = self.Emitter:Add( "effects/fleck_cement" .. math.random( 1, 2 ), self.Pos + self.DirVec )
 
         if ( Shrapnel ) then
@@ -362,7 +354,7 @@ function EFFECT:Sand()
     end
 
     -- Blast flash
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -379,7 +371,7 @@ function EFFECT:Sand()
         end
     end
 
-    for i = 0, 10 * self.Scale do
+    for _ = 0, 10 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Smoke ) then
@@ -397,7 +389,7 @@ function EFFECT:Sand()
         end
     end
 
-    for i = 0, 5 * self.Scale do
+    for _ = 0, 5 * self.Scale do
         local Whisp = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Whisp ) then
@@ -418,8 +410,8 @@ function EFFECT:Sand()
     local Density = 40 * self.Scale --/ This part is for the dust ring ///
     local Angle = self.DirVec:Angle()
 
-    for i = 0, Density do
-        Angle:RotateAroundAxis( Angle:Forward(), ( 360 / Density ) )
+    for _ = 0, Density do
+        Angle:RotateAroundAxis( Angle:Forward(), 360 / Density )
         local ShootVector = Angle:Up()
         local Smoke = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
@@ -443,7 +435,7 @@ function EFFECT:Metal()
     WorldSound( "Bullet.Impact", self.Pos )
 
     -- Blast flash
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -460,7 +452,7 @@ function EFFECT:Metal()
         end
     end
 
-    for i = 0, 30 * self.Scale do
+    for _ = 0, 30 * self.Scale do
         local Whisp = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Whisp ) then
@@ -478,7 +470,7 @@ function EFFECT:Metal()
         end
     end
 
-    for i = 0, 30 * self.Scale do
+    for _ = 0, 30 * self.Scale do
         local Sparks = self.Emitter:Add( "effects/spark", self.Pos )
 
         if ( Sparks ) then
@@ -494,7 +486,7 @@ function EFFECT:Metal()
         end
     end
 
-    for i = 0, 10 * self.Scale do
+    for _ = 0, 10 * self.Scale do
         local Sparks = self.Emitter:Add( "effects/yellowflare", self.Pos )
 
         if ( Sparks ) then
@@ -515,7 +507,7 @@ function EFFECT:Smoke()
     WorldSound( "Bullet.Impact", self.Pos )
 
     -- Blast flash
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -532,7 +524,7 @@ function EFFECT:Smoke()
         end
     end
 
-    for i = 0, 30 * self.Scale do
+    for _ = 0, 30 * self.Scale do
         local Whisp = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Whisp ) then
@@ -550,7 +542,7 @@ function EFFECT:Smoke()
         end
     end
 
-    for i = 1, 25 * self.Scale do
+    for _ = 1, 25 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_tile" .. math.random( 1, 2 ), self.Pos )
 
         if ( Debris ) then
@@ -570,8 +562,8 @@ function EFFECT:Smoke()
     local Angle = self.DirVec:Angle()
 
     --/ This part makes the trailers ///
-    for i = 1, self.DebrizzlemyNizzle do
-        Angle:RotateAroundAxis( Angle:Forward(), ( 360 / self.DebrizzlemyNizzle ) )
+    for _ = 1, self.DebrizzlemyNizzle do
+        Angle:RotateAroundAxis( Angle:Forward(), 360 / self.DebrizzlemyNizzle )
         local DustRing = Angle:Up()
         local RanVec = self.DirVec * math.Rand( 1, 4 ) + ( DustRing * math.Rand( 3, 4 ) )
 
@@ -594,7 +586,7 @@ function EFFECT:Smoke()
 end
 
 function EFFECT:Wood()
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -611,7 +603,7 @@ function EFFECT:Wood()
         end
     end
 
-    for i = 0, 30 * self.Scale do
+    for _ = 0, 30 * self.Scale do
         local Whisp = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Whisp ) then
@@ -629,7 +621,7 @@ function EFFECT:Wood()
         end
     end
 
-    for i = 0, 20 * self.Scale do
+    for _ = 0, 20 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_wood" .. math.random( 1, 2 ), self.Pos + self.DirVec )
 
         if ( Debris ) then
@@ -649,7 +641,7 @@ end
 
 function EFFECT:Glass()
     -- Blast flash
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -666,7 +658,7 @@ function EFFECT:Glass()
         end
     end
 
-    for i = 0, 30 * self.Scale do
+    for _ = 0, 30 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_glass" .. math.random( 1, 3 ), self.Pos )
 
         if ( Debris ) then
@@ -685,7 +677,7 @@ function EFFECT:Glass()
         end
     end
 
-    for i = 0, 30 * self.Scale do
+    for _ = 0, 30 * self.Scale do
         local Whisp = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Whisp ) then
@@ -706,7 +698,7 @@ end
 
 function EFFECT:Blood()
     -- If you recieve over 50,000 joules of energy, you become red mist.
-    for i = 0, 30 * self.Scale do
+    for _ = 0, 30 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/particle_composite", self.Pos )
 
         if ( Smoke ) then
@@ -725,7 +717,7 @@ function EFFECT:Blood()
     end
 
     -- Add some finer details....
-    for i = 0, 20 * self.Scale do
+    for _ = 0, 20 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Smoke ) then
@@ -744,7 +736,7 @@ function EFFECT:Blood()
     end
 
     -- Into the flash!
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -762,7 +754,7 @@ function EFFECT:Blood()
     end
 
     -- Chunkage NOT contained
-    for i = 1, 20 * self.Scale do
+    for _ = 1, 20 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_cement" .. math.random( 1, 2 ), self.Pos - ( self.DirVec * 5 ) )
 
         if ( Debris ) then
@@ -785,7 +777,7 @@ end
 
 function EFFECT:YellowBlood()
     -- If you recieve over 50,000 joules of energy, you become red mist.
-    for i = 0, 30 * self.Scale do
+    for _ = 0, 30 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/particle_composite", self.Pos )
 
         if ( Smoke ) then
@@ -804,7 +796,7 @@ function EFFECT:YellowBlood()
     end
 
     -- Add some finer details....
-    for i = 0, 20 * self.Scale do
+    for _ = 0, 20 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Smoke ) then
@@ -823,7 +815,7 @@ function EFFECT:YellowBlood()
     end
 
     -- Into the flash!
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -841,7 +833,7 @@ function EFFECT:YellowBlood()
     end
 
     -- Chunkage NOT contained
-    for i = 1, 20 * self.Scale do
+    for _ = 1, 20 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_cement" .. math.random( 1, 2 ), self.Pos - ( self.DirVec * 5 ) )
 
         if ( Debris ) then

--- a/lua/effects/gdca_cinematicboom_t/init.lua
+++ b/lua/effects/gdca_cinematicboom_t/init.lua
@@ -71,7 +71,7 @@ function EFFECT:Init( data )
 end
 
 function EFFECT:Dust()
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -103,7 +103,7 @@ function EFFECT:Dust()
         Distort:SetColor( 255, 255, 255 )
     end
 
-    for i = 1, 20 * self.Scale do
+    for _ = 1, 20 * self.Scale do
         local Dust = self.Emitter:Add( "particle/particle_composite", self.Pos )
 
         if ( Dust ) then
@@ -111,8 +111,8 @@ function EFFECT:Dust()
             Dust:SetDieTime( math.Rand( 2, 3 ) )
             Dust:SetStartAlpha( 230 )
             Dust:SetEndAlpha( 0 )
-            Dust:SetStartSize( ( 50 * self.Scale ) )
-            Dust:SetEndSize( ( 100 * self.Scale ) )
+            Dust:SetStartSize( 50 * self.Scale )
+            Dust:SetEndSize( 100 * self.Scale )
             Dust:SetRoll( math.Rand( 150, 360 ) )
             Dust:SetRollDelta( math.Rand( -1, 1 ) )
             Dust:SetAirResistance( 150 )
@@ -121,7 +121,7 @@ function EFFECT:Dust()
         end
     end
 
-    for i = 1, 15 * self.Scale do
+    for _ = 1, 15 * self.Scale do
         local Dust = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Dust ) then
@@ -129,8 +129,8 @@ function EFFECT:Dust()
             Dust:SetDieTime( math.Rand( 1, 5 ) * self.Scale )
             Dust:SetStartAlpha( 50 )
             Dust:SetEndAlpha( 0 )
-            Dust:SetStartSize( ( 80 * self.Scale ) )
-            Dust:SetEndSize( ( 100 * self.Scale ) )
+            Dust:SetStartSize( 80 * self.Scale )
+            Dust:SetEndSize( 100 * self.Scale )
             Dust:SetRoll( math.Rand( 150, 360 ) )
             Dust:SetRollDelta( math.Rand( -1, 1 ) )
             Dust:SetAirResistance( 250 )
@@ -139,7 +139,7 @@ function EFFECT:Dust()
         end
     end
 
-    for i = 1, 25 * self.Scale do
+    for _ = 1, 25 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_cement" .. math.random( 1, 2 ), self.Pos )
 
         if ( Debris ) then
@@ -159,8 +159,8 @@ function EFFECT:Dust()
     local Angle = self.DirVec:Angle()
 
     --/ This part makes the trailers ///
-    for i = 1, self.DebrizzlemyNizzle do
-        Angle:RotateAroundAxis( Angle:Forward(), ( 360 / self.DebrizzlemyNizzle ) )
+    for _ = 1, self.DebrizzlemyNizzle do
+        Angle:RotateAroundAxis( Angle:Forward(), 360 / self.DebrizzlemyNizzle )
         local DustRing = Angle:Up()
         local RanVec = self.DirVec * math.Rand( 1, 5 ) + ( DustRing * math.Rand( 2, 5 ) )
 
@@ -183,7 +183,7 @@ function EFFECT:Dust()
 end
 
 function EFFECT:Dirt()
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -215,7 +215,7 @@ function EFFECT:Dirt()
         Distort:SetColor( 255, 255, 255 )
     end
 
-    for i = 1, 20 * self.Scale do
+    for _ = 1, 20 * self.Scale do
         local Dust = self.Emitter:Add( "particle/particle_composite", self.Pos )
 
         if ( Dust ) then
@@ -223,8 +223,8 @@ function EFFECT:Dirt()
             Dust:SetDieTime( math.Rand( 2, 3 ) )
             Dust:SetStartAlpha( 230 )
             Dust:SetEndAlpha( 0 )
-            Dust:SetStartSize( ( 50 * self.Scale ) )
-            Dust:SetEndSize( ( 100 * self.Scale ) )
+            Dust:SetStartSize( 50 * self.Scale )
+            Dust:SetEndSize( 100 * self.Scale )
             Dust:SetRoll( math.Rand( 150, 360 ) )
             Dust:SetRollDelta( math.Rand( -1, 1 ) )
             Dust:SetAirResistance( 150 )
@@ -233,7 +233,7 @@ function EFFECT:Dirt()
         end
     end
 
-    for i = 1, 15 * self.Scale do
+    for _ = 1, 15 * self.Scale do
         local Dust = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Dust ) then
@@ -241,8 +241,8 @@ function EFFECT:Dirt()
             Dust:SetDieTime( math.Rand( 1, 5 ) * self.Scale )
             Dust:SetStartAlpha( 50 )
             Dust:SetEndAlpha( 0 )
-            Dust:SetStartSize( ( 80 * self.Scale ) )
-            Dust:SetEndSize( ( 100 * self.Scale ) )
+            Dust:SetStartSize( 80 * self.Scale )
+            Dust:SetEndSize( 100 * self.Scale )
             Dust:SetRoll( math.Rand( 150, 360 ) )
             Dust:SetRollDelta( math.Rand( -1, 1 ) )
             Dust:SetAirResistance( 250 )
@@ -251,7 +251,7 @@ function EFFECT:Dirt()
         end
     end
 
-    for i = 1, 25 * self.Scale do
+    for _ = 1, 25 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_cement" .. math.random( 1, 2 ), self.Pos )
 
         if ( Debris ) then
@@ -271,8 +271,8 @@ function EFFECT:Dirt()
     local Angle = self.DirVec:Angle()
 
     --/ This part makes the trailers ///
-    for i = 1, self.DebrizzlemyNizzle do
-        Angle:RotateAroundAxis( Angle:Forward(), ( 360 / self.DebrizzlemyNizzle ) )
+    for _ = 1, self.DebrizzlemyNizzle do
+        Angle:RotateAroundAxis( Angle:Forward(), 360 / self.DebrizzlemyNizzle )
         local DustRing = Angle:Up()
         local RanVec = self.DirVec * math.Rand( 2, 6 ) + ( DustRing * math.Rand( 1, 4 ) )
 
@@ -296,7 +296,7 @@ end
 
 function EFFECT:Sand()
     -- This is the main plume
-    for i = 0, 45 * self.Scale do
+    for _ = 0, 45 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Smoke ) then
@@ -330,7 +330,7 @@ function EFFECT:Sand()
     end
 
     -- This is the dirt kickup
-    for i = 0, 20 * self.Scale do
+    for _ = 0, 20 * self.Scale do
         local Dust = self.Emitter:Add( "particle/particle_composite", self.Pos )
 
         if ( Dust ) then
@@ -349,7 +349,7 @@ function EFFECT:Sand()
     end
 
     -- Chunkage
-    for i = 0, 25 * self.Scale do
+    for _ = 0, 25 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_cement" .. math.random( 1, 2 ), self.Pos )
 
         if ( Debris ) then
@@ -367,7 +367,7 @@ function EFFECT:Sand()
     end
 
     -- Shrapnel
-    for i = 0, 25 * self.Scale do
+    for _ = 0, 25 * self.Scale do
         local Shrapnel = self.Emitter:Add( "effects/fleck_cement" .. math.random( 1, 2 ), self.Pos + self.DirVec )
 
         if ( Shrapnel ) then
@@ -387,7 +387,7 @@ function EFFECT:Sand()
     end
 
     -- Blast flash
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -404,7 +404,7 @@ function EFFECT:Sand()
         end
     end
 
-    for i = 0, 10 * self.Scale do
+    for _ = 0, 10 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Smoke ) then
@@ -422,7 +422,7 @@ function EFFECT:Sand()
         end
     end
 
-    for i = 0, 5 * self.Scale do
+    for _ = 0, 5 * self.Scale do
         local Whisp = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Whisp ) then
@@ -443,8 +443,8 @@ function EFFECT:Sand()
     local Density = 40 * self.Scale --/ This part is for the dust ring ///
     local Angle = self.DirVec:Angle()
 
-    for i = 0, Density do
-        Angle:RotateAroundAxis( Angle:Forward(), ( 360 / Density ) )
+    for _ = 0, Density do
+        Angle:RotateAroundAxis( Angle:Forward(), 360 / Density )
         local ShootVector = Angle:Up()
         local Smoke = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
@@ -466,7 +466,7 @@ end
 
 function EFFECT:Metal()
     -- Blast flash
-    for i = 1, 3 do
+    for _ = 1, 3 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -498,7 +498,7 @@ function EFFECT:Metal()
         Distort:SetColor( 255, 255, 255 )
     end
 
-    for i = 0, 20 * self.Scale do
+    for _ = 0, 20 * self.Scale do
         local Whisp = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Whisp ) then
@@ -516,7 +516,7 @@ function EFFECT:Metal()
         end
     end
 
-    for i = 0, 30 * self.Scale do
+    for _ = 0, 30 * self.Scale do
         local Sparks = self.Emitter:Add( "effects/spark", self.Pos )
 
         if ( Sparks ) then
@@ -532,7 +532,7 @@ function EFFECT:Metal()
         end
     end
 
-    for i = 0, 10 * self.Scale do
+    for _ = 0, 10 * self.Scale do
         local Sparks = self.Emitter:Add( "effects/yellowflare", self.Pos )
 
         if ( Sparks ) then
@@ -551,7 +551,7 @@ end
 
 function EFFECT:Smoke()
     -- Blast flash
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -583,7 +583,7 @@ function EFFECT:Smoke()
         Distort:SetColor( 255, 255, 255 )
     end
 
-    for i = 0, 20 * self.Scale do
+    for _ = 0, 20 * self.Scale do
         local Whisp = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Whisp ) then
@@ -601,7 +601,7 @@ function EFFECT:Smoke()
         end
     end
 
-    for i = 1, 25 * self.Scale do
+    for _ = 1, 25 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_tile" .. math.random( 1, 2 ), self.Pos )
 
         if ( Debris ) then
@@ -621,8 +621,8 @@ function EFFECT:Smoke()
     local Angle = self.DirVec:Angle()
 
     --/ This part makes the trailers ///
-    for i = 1, self.DebrizzlemyNizzle do
-        Angle:RotateAroundAxis( Angle:Forward(), ( 360 / self.DebrizzlemyNizzle ) )
+    for _ = 1, self.DebrizzlemyNizzle do
+        Angle:RotateAroundAxis( Angle:Forward(), 360 / self.DebrizzlemyNizzle )
         local DustRing = Angle:Up()
         local RanVec = self.DirVec * math.Rand( 1, 4 ) + ( DustRing * math.Rand( 3, 4 ) )
 
@@ -645,7 +645,7 @@ function EFFECT:Smoke()
 end
 
 function EFFECT:Wood()
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -677,7 +677,7 @@ function EFFECT:Wood()
         Distort:SetColor( 255, 255, 255 )
     end
 
-    for i = 0, 30 * self.Scale do
+    for _ = 0, 30 * self.Scale do
         local Whisp = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Whisp ) then
@@ -695,7 +695,7 @@ function EFFECT:Wood()
         end
     end
 
-    for i = 0, 20 * self.Scale do
+    for _ = 0, 20 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_wood" .. math.random( 1, 2 ), self.Pos + self.DirVec )
 
         if ( Debris ) then
@@ -715,7 +715,7 @@ end
 
 function EFFECT:Glass()
     -- Blast flash
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -747,7 +747,7 @@ function EFFECT:Glass()
         Distort:SetColor( 255, 255, 255 )
     end
 
-    for i = 0, 30 * self.Scale do
+    for _ = 0, 30 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_glass" .. math.random( 1, 3 ), self.Pos )
 
         if ( Debris ) then
@@ -766,7 +766,7 @@ function EFFECT:Glass()
         end
     end
 
-    for i = 0, 30 * self.Scale do
+    for _ = 0, 30 * self.Scale do
         local Whisp = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Whisp ) then
@@ -787,7 +787,7 @@ end
 
 function EFFECT:Blood()
     -- If you recieve over 50,000 joules of energy, you become red mist.
-    for i = 0, 30 * self.Scale do
+    for _ = 0, 30 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/particle_composite", self.Pos )
 
         if ( Smoke ) then
@@ -821,7 +821,7 @@ function EFFECT:Blood()
     end
 
     -- Add some finer details....
-    for i = 0, 20 * self.Scale do
+    for _ = 0, 20 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Smoke ) then
@@ -840,7 +840,7 @@ function EFFECT:Blood()
     end
 
     -- Into the flash!
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -858,7 +858,7 @@ function EFFECT:Blood()
     end
 
     -- Chunkage NOT contained
-    for i = 1, 20 * self.Scale do
+    for _ = 1, 20 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_cement" .. math.random( 1, 2 ), self.Pos - ( self.DirVec * 5 ) )
 
         if ( Debris ) then
@@ -881,7 +881,7 @@ end
 
 function EFFECT:YellowBlood()
     -- If you recieve over 50,000 joules of energy, you become red mist.
-    for i = 0, 30 * self.Scale do
+    for _ = 0, 30 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/particle_composite", self.Pos )
 
         if ( Smoke ) then
@@ -915,7 +915,7 @@ function EFFECT:YellowBlood()
     end
 
     -- Add some finer details....
-    for i = 0, 20 * self.Scale do
+    for _ = 0, 20 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/smokesprites_000" .. math.random( 1, 9 ), self.Pos )
 
         if ( Smoke ) then
@@ -934,7 +934,7 @@ function EFFECT:YellowBlood()
     end
 
     -- Into the flash!
-    for i = 1, 5 do
+    for _ = 1, 5 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Pos )
 
         if ( Flash ) then
@@ -952,7 +952,7 @@ function EFFECT:YellowBlood()
     end
 
     -- Chunkage NOT contained
-    for i = 1, 20 * self.Scale do
+    for _ = 1, 20 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_cement" .. math.random( 1, 2 ), self.Pos - ( self.DirVec * 5 ) )
 
         if ( Debris ) then

--- a/lua/effects/gdcw_universal_impact_t/init.lua
+++ b/lua/effects/gdcw_universal_impact_t/init.lua
@@ -63,7 +63,7 @@ function EFFECT:Dust()
     sound.Play( "Bullet.Impact", self.Origin )
     self.Emitter = ParticleEmitter( self.Origin )
 
-    for i = 0, 15 * self.Scale do
+    for _ = 0, 15 * self.Scale do
         local Smoke = self.Emitter:Add( "particles/smokey", self.Origin )
 
         if ( Smoke ) then
@@ -81,7 +81,7 @@ function EFFECT:Dust()
         end
     end
 
-    for i = 0, 10 * self.Scale do
+    for _ = 0, 10 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/particle_composite", self.Origin )
 
         if ( Smoke ) then
@@ -99,7 +99,7 @@ function EFFECT:Dust()
         end
     end
 
-    for i = 0, 10 * self.Scale do
+    for _ = 0, 10 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_cement" .. math.random( 1, 2 ), self.Origin )
 
         if ( Debris ) then
@@ -118,7 +118,7 @@ function EFFECT:Dust()
         end
     end
 
-    for i = 0, 1 do
+    for _ = 0, 1 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Origin )
 
         if ( Flash ) then
@@ -140,7 +140,7 @@ function EFFECT:Dirt()
     sound.Play( "Bullet.Impact", self.Origin )
     self.Emitter = ParticleEmitter( self.Origin )
 
-    for i = 0, 15 * self.Scale do
+    for _ = 0, 15 * self.Scale do
         local Smoke = self.Emitter:Add( "particles/smokey", self.Origin )
 
         if ( Smoke ) then
@@ -158,7 +158,7 @@ function EFFECT:Dirt()
         end
     end
 
-    for i = 0, 10 * self.Scale do
+    for _ = 0, 10 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/particle_composite", self.Origin )
 
         if ( Smoke ) then
@@ -176,7 +176,7 @@ function EFFECT:Dirt()
         end
     end
 
-    for i = 0, 15 * self.Scale do
+    for _ = 0, 15 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_cement" .. math.random( 1, 2 ), self.Origin )
 
         if ( Debris ) then
@@ -195,7 +195,7 @@ function EFFECT:Dirt()
         end
     end
 
-    for i = 0, 1 do
+    for _ = 0, 1 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Origin )
 
         if ( Flash ) then
@@ -217,7 +217,7 @@ function EFFECT:Sand()
     sound.Play( "Bullet.Impact", self.Origin )
     self.Emitter = ParticleEmitter( self.Origin )
 
-    for i = 0, 15 * self.Scale do
+    for _ = 0, 15 * self.Scale do
         local Smoke = self.Emitter:Add( "particles/smokey", self.Origin )
 
         if ( Smoke ) then
@@ -235,7 +235,7 @@ function EFFECT:Sand()
         end
     end
 
-    for i = 0, 20 * self.Scale do
+    for _ = 0, 20 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/particle_composite", self.Origin )
 
         if ( Smoke ) then
@@ -258,7 +258,7 @@ function EFFECT:Metal()
     sound.Play( "Bullet.Impact", self.Origin )
     self.Emitter = ParticleEmitter( self.Origin )
 
-    for i = 0, 15 * self.Scale do
+    for _ = 0, 15 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/smokestack", self.Origin )
 
         if ( Smoke ) then
@@ -276,7 +276,7 @@ function EFFECT:Metal()
         end
     end
 
-    for i = 0, 3 do
+    for _ = 0, 3 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Origin )
 
         if ( Flash ) then
@@ -293,7 +293,7 @@ function EFFECT:Metal()
         end
     end
 
-    for i = 0, 20 * self.Scale do
+    for _ = 0, 20 * self.Scale do
         local particle = self.Emitter:Add( "effects/spark", self.Origin )
 
         if ( particle ) then
@@ -314,7 +314,7 @@ function EFFECT:Smoke()
     sound.Play( "Bullet.Impact", self.Origin )
     self.Emitter = ParticleEmitter( self.Origin )
 
-    for i = 0, 15 * self.Scale do
+    for _ = 0, 15 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/smokestack", self.Origin )
 
         if ( Smoke ) then
@@ -332,7 +332,7 @@ function EFFECT:Smoke()
         end
     end
 
-    for i = 0, 15 * self.Scale do
+    for _ = 0, 15 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_tile" .. math.random( 1, 2 ), self.Origin )
 
         if ( Debris ) then
@@ -351,7 +351,7 @@ function EFFECT:Smoke()
         end
     end
 
-    for i = 0, 1 do
+    for _ = 0, 1 do
         local Flash = self.Emitter:Add( "effects/muzzleflash" .. math.random( 1, 4 ), self.Origin )
 
         if ( Flash ) then
@@ -373,7 +373,7 @@ function EFFECT:Wood()
     sound.Play( "Bullet.Impact", self.Origin )
     self.Emitter = ParticleEmitter( self.Origin )
 
-    for i = 0, 5 * self.Scale do
+    for _ = 0, 5 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/smokestack", self.Origin )
 
         if ( Smoke ) then
@@ -391,7 +391,7 @@ function EFFECT:Wood()
         end
     end
 
-    for i = 0, 10 * self.Scale do
+    for _ = 0, 10 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/smokestack", self.Origin )
 
         if ( Smoke ) then
@@ -409,7 +409,7 @@ function EFFECT:Wood()
         end
     end
 
-    for i = 0, 15 * self.Scale do
+    for _ = 0, 15 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_wood" .. math.random( 1, 2 ), self.Origin + self.DirVec )
 
         if ( Debris ) then
@@ -430,7 +430,7 @@ function EFFECT:Wood()
 end
 
 function EFFECT:Glass()
-    for i = 0, 10 * self.Scale do
+    for _ = 0, 10 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_glass" .. math.random( 1, 3 ), self.Origin + self.DirVec )
 
         if ( Debris ) then
@@ -449,7 +449,7 @@ function EFFECT:Glass()
         end
     end
 
-    for i = 0, 20 * self.Scale do
+    for _ = 0, 20 * self.Scale do
         local Debris = self.Emitter:Add( "effects/fleck_glass" .. math.random( 1, 3 ), self.Origin )
 
         if ( Debris ) then
@@ -468,7 +468,7 @@ function EFFECT:Glass()
 end
 
 function EFFECT:Blood()
-    for i = 0, 10 * self.Scale do
+    for _ = 0, 10 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/particle_composite", self.Origin )
 
         if ( Smoke ) then
@@ -488,7 +488,7 @@ function EFFECT:Blood()
 end
 
 function EFFECT:YellowBlood()
-    for i = 0, 10 * self.Scale do
+    for _ = 0, 10 * self.Scale do
         local Smoke = self.Emitter:Add( "particle/particle_composite", self.Origin )
 
         if ( Smoke ) then

--- a/lua/entities/rail_shell/init.lua
+++ b/lua/entities/rail_shell/init.lua
@@ -55,13 +55,13 @@ function ENT:Splode( tr )
         directDamage = 400
     end
 
-    local Damage = DamageInfo()
-    Damage:SetDamageType( DMG_BLAST )
-    Damage:SetDamage( directDamage )
-    Damage:SetDamageForce( self:GetForward() * 70000 )
-    Damage:SetAttacker( attacker )
-    Damage:SetInflictor( inflictor )
-    tr.Entity:TakeDamageInfo( Damage )
+    local damage = DamageInfo()
+    damage:SetDamageType( DMG_BLAST )
+    damage:SetDamage( directDamage )
+    damage:SetDamageForce( self:GetForward() * 70000 )
+    damage:SetAttacker( attacker )
+    damage:SetInflictor( inflictor )
+    tr.Entity:TakeDamageInfo( damage )
 
     local concrete = 67 -- has to be concrete else errors are spammed
     local effectdata = EffectData()

--- a/lua/entities/rail_shell/init.lua
+++ b/lua/entities/rail_shell/init.lua
@@ -12,33 +12,31 @@ function ENT:Initialize()
     self:PhysicsInit( SOLID_VPHYSICS ) -- Make us work with physics,
     self:SetMoveType( MOVETYPE_NONE ) --after all, gmod is a physics
     self:SetSolid( SOLID_VPHYSICS ) -- CHEESECAKE!	>:3
-    Tracer = ents.Create( "env_spritetrail" )
-    Tracer:SetKeyValue( "lifetime", "1.5" )
-    Tracer:SetKeyValue( "startwidth", "100" )
-    Tracer:SetKeyValue( "endwidth", "30" )
-    Tracer:SetKeyValue( "spritename", "trails/laser.vmt" )
-    Tracer:SetKeyValue( "rendermode", "5" )
-    Tracer:SetKeyValue( "rendercolor", "37 138 210" )
-    Tracer:SetPos( self:GetPos() )
-    Tracer:Spawn()
-    Tracer:Activate()
+    local tracer = ents.Create( "env_spritetrail" )
+    tracer:SetKeyValue( "lifetime", "1.5" )
+    tracer:SetKeyValue( "startwidth", "100" )
+    tracer:SetKeyValue( "endwidth", "30" )
+    tracer:SetKeyValue( "spritename", "trails/laser.vmt" )
+    tracer:SetKeyValue( "rendermode", "5" )
+    tracer:SetKeyValue( "rendercolor", "37 138 210" )
+    tracer:SetPos( self:GetPos() )
+    tracer:Spawn()
+    tracer:Activate()
 
-    self.Tracer = Tracer
+    self.Tracer = tracer
 
-    Glow = ents.Create( "env_sprite" )
-    Glow:SetKeyValue( "model", "orangecore2.vmt" )
-    Glow:SetKeyValue( "rendercolor", "37 138 210" )
-    Glow:SetKeyValue( "scale", "0.4" )
-    Glow:SetPos( self:GetPos() )
-    Glow:SetParent( self )
-    Glow:Spawn()
-    Glow:Activate()
+    local glow = ents.Create( "env_sprite" )
+    glow:SetKeyValue( "model", "orangecore2.vmt" )
+    glow:SetKeyValue( "rendercolor", "37 138 210" )
+    glow:SetKeyValue( "scale", "0.4" )
+    glow:SetPos( self:GetPos() )
+    glow:SetParent( self )
+    glow:Spawn()
+    glow:Activate()
+
 end
 
 function ENT:Splode( tr )
-
-    self.Tracer:SetPos( self:GetPos() )
-    SafeRemoveEntityDelayed( self.Tracer, 5 )
 
     -- damage equals 400 multipled by a bit less than the firing interval
     local baseDamage = 1188
@@ -82,12 +80,23 @@ function ENT:Splode( tr )
 
     self:Remove()
 
+    if not IsValid( self.Tracer ) then return end
+    self.Tracer:SetPos( self:GetPos() )
+    SafeRemoveEntityDelayed( self.Tracer, 5 )
+
 end
 
 function ENT:Think()
     if self.timeleft < CurTime() then
         self:Remove()
     end
+
+    local trace = {}
+    trace.start = self:GetPos()
+    trace.endpos = self:GetPos() + self.flightvector
+    trace.filter = self
+    trace.mask = bit.bxor( MASK_SHOT, MASK_WATER ) -- Trace for stuff that bullets would normally hit
+    local tr = util.TraceLine( trace )
 
     if self.AirburstTime < CurTime() then
         local owner = IsValid( self:GetOwner() ) and self:GetOwner()
@@ -101,13 +110,6 @@ function ENT:Think()
 
         self:Splode()
     end
-    
-    local trace = {}
-    trace.start = self:GetPos()
-    trace.endpos = self:GetPos() + self.flightvector
-    trace.filter = self
-    trace.mask = bit.bxor( MASK_SHOT, MASK_WATER ) -- Trace for stuff that bullets would normally hit
-    local tr = util.TraceLine( trace )
 
     if tr.Hit then
         if tr.HitSky then
@@ -135,6 +137,8 @@ function ENT:Think()
     self.flightvector = self.flightvector + ( Vector( math.Rand( -0.1, 0.1 ), math.Rand( -0.1, 0.1 ), math.Rand( -0.1, 0.1 ) ) + Vector( 0, 0, -0.01 ) )
     self:SetAngles( self.flightvector:Angle() )
     self:NextThink( CurTime() )
+
+    if not IsValid( self.Tracer ) then return true end
 
     self.Tracer:SetPos( self:GetPos() ) -- use SetPos in think to prevent stupid bug where tracer jumps up to origin when unparented
 

--- a/lua/entities/rail_shell/init.lua
+++ b/lua/entities/rail_shell/init.lua
@@ -35,7 +35,7 @@ function ENT:Initialize()
     glow:Activate()
 end
 
-function ENT:Splode( tr )
+function ENT:Explode( tr )
     -- damage equals 400 multipled by a bit less than the firing interval
     local baseDamage = 1188
     local effectDir = -self:GetForward() --have the effect "point" towards the turret, makes it very clear where you are being shot from
@@ -106,7 +106,7 @@ function ENT:Think()
             end
         end
 
-        self:Splode()
+        self:Explode()
     end
 
     if tr.Hit then
@@ -128,7 +128,7 @@ function ENT:Think()
             return true
         end
 
-        self:Splode( tr )
+        self:Explode( tr )
 
     end
     self:SetPos( self:GetPos() + self.flightvector )

--- a/lua/entities/rail_shell/init.lua
+++ b/lua/entities/rail_shell/init.lua
@@ -33,11 +33,9 @@ function ENT:Initialize()
     glow:SetParent( self )
     glow:Spawn()
     glow:Activate()
-
 end
 
 function ENT:Splode( tr )
-
     -- damage equals 400 multipled by a bit less than the firing interval
     local baseDamage = 1188
     local effectDir = -self:GetForward() --have the effect "point" towards the turret, makes it very clear where you are being shot from
@@ -83,7 +81,6 @@ function ENT:Splode( tr )
     if not IsValid( self.Tracer ) then return end
     self.Tracer:SetPos( self:GetPos() )
     SafeRemoveEntityDelayed( self.Tracer, 5 )
-
 end
 
 function ENT:Think()
@@ -99,6 +96,7 @@ function ENT:Think()
     local tr = util.TraceLine( trace )
 
     if self.AirburstTime < CurTime() then
+
         local owner = IsValid( self:GetOwner() ) and self:GetOwner()
         local inflictor = owner
         if not IsValid( owner ) then

--- a/lua/entities/turret_40mm_frag/init.lua
+++ b/lua/entities/turret_40mm_frag/init.lua
@@ -10,33 +10,30 @@ function ENT:Initialize()
     self:SetMoveType( MOVETYPE_NONE ) --after all, gmod is a physics
     self:SetSolid( SOLID_VPHYSICS ) -- CHEESECAKE!	>:3
 
-    Tracer = ents.Create( "env_spritetrail" )
-    Tracer:SetKeyValue( "lifetime", "0.3" )
-    Tracer:SetKeyValue( "startwidth", "32" )
-    Tracer:SetKeyValue( "endwidth", "0" )
-    Tracer:SetKeyValue( "spritename", "trails/laser.vmt" )
-    Tracer:SetKeyValue( "rendermode", "5" )
-    Tracer:SetKeyValue( "rendercolor", "255 255 255" )
-    Tracer:SetPos( self:GetPos() )
-    Tracer:Spawn()
-    Tracer:Activate()
+    local tracer = ents.Create( "env_spritetrail" )
+    tracer:SetKeyValue( "lifetime", "0.3" )
+    tracer:SetKeyValue( "startwidth", "32" )
+    tracer:SetKeyValue( "endwidth", "0" )
+    tracer:SetKeyValue( "spritename", "trails/laser.vmt" )
+    tracer:SetKeyValue( "rendermode", "5" )
+    tracer:SetKeyValue( "rendercolor", "255 255 255" )
+    tracer:SetPos( self:GetPos() )
+    tracer:Spawn()
+    tracer:Activate()
 
-    self.Tracer = Tracer
+    self.tracer = tracer
 
-    Glow = ents.Create( "env_sprite" )
-    Glow:SetKeyValue( "model", "orangecore2.vmt" )
-    Glow:SetKeyValue( "rendercolor", "37 138 210" )
-    Glow:SetKeyValue( "scale", "0.1" )
-    Glow:SetPos( self:GetPos() )
-    Glow:SetParent( self )
-    Glow:Spawn()
-    Glow:Activate()
+    local glow = ents.Create( "env_sprite" )
+    glow:SetKeyValue( "model", "orangecore2.vmt" )
+    glow:SetKeyValue( "rendercolor", "37 138 210" )
+    glow:SetKeyValue( "scale", "0.1" )
+    glow:SetPos( self:GetPos() )
+    glow:SetParent( self )
+    glow:Spawn()
+    glow:Activate()
 end
 
 function ENT:Explode()
-
-    self.Tracer:SetPos( self:GetPos() )
-    SafeRemoveEntityDelayed( self.Tracer, 5 )
 
     -- damage equals 400 multiplied by two thirds of this turret's firing speed
     local baseDamage = 120
@@ -61,7 +58,13 @@ function ENT:Explode()
     util.Effect( "gdca_airburst_t", effectdata )
     util.ScreenShake( origin, 10, 5, 1, 1300 )
     util.Decal( "Scorch", origin + normal, origin - normal )
+
     self:Remove()
+
+    if not IsValid( self.tracer ) then return end
+    self.tracer:SetPos( self:GetPos() )
+    SafeRemoveEntityDelayed( self.tracer, 5 )
+
 end
 
 function ENT:Think()
@@ -103,7 +106,9 @@ function ENT:Think()
     self:SetAngles( self.flightvector:Angle() )
     self:NextThink( CurTime() )
 
-    self.Tracer:SetPos( self:GetPos() ) -- use SetPos in think to prevent stupid bug where tracer jumps up to origin when unparented
+    if not IsValid( self.tracer ) then return true end
+
+    self.tracer:SetPos( self:GetPos() ) -- use SetPos in think to prevent stupid bug where tracer jumps up to origin when unparented
 
     return true
 end

--- a/lua/entities/turret_40mm_frag/init.lua
+++ b/lua/entities/turret_40mm_frag/init.lua
@@ -34,7 +34,6 @@ function ENT:Initialize()
 end
 
 function ENT:Explode()
-
     -- damage equals 400 multiplied by two thirds of this turret's firing speed
     local baseDamage = 120
     local origin = self:GetPos()
@@ -64,7 +63,6 @@ function ENT:Explode()
     if not IsValid( self.tracer ) then return end
     self.tracer:SetPos( self:GetPos() )
     SafeRemoveEntityDelayed( self.tracer, 5 )
-
 end
 
 function ENT:Think()

--- a/lua/entities/turret_40mm_frag/init.lua
+++ b/lua/entities/turret_40mm_frag/init.lua
@@ -32,7 +32,7 @@ end
 
 function ENT:Explode()
     -- damage equals 400 multiplied by two thirds of this turret's firing speed
-    local baseDamage = 185
+    local baseDamage = 120
     local origin = self:GetPos()
     local normal = self.flightvector:GetNormalized()
 
@@ -40,7 +40,7 @@ function ENT:Explode()
     local attacker = owner or self.Turret or self
     local inflictor = self
 
-    util.BlastDamage( inflictor, attacker, self:GetPos(), 350, baseDamage )
+    util.BlastDamage( inflictor, attacker, self:GetPos(), 400, baseDamage )
 
     local concrete = 67 -- has to be concrete else errors are spammed
     local effectdata = EffectData()

--- a/lua/entities/turret_40mm_frag/init.lua
+++ b/lua/entities/turret_40mm_frag/init.lua
@@ -9,6 +9,7 @@ function ENT:Initialize()
     self:PhysicsInit( SOLID_VPHYSICS ) -- Make us work with physics,
     self:SetMoveType( MOVETYPE_NONE ) --after all, gmod is a physics
     self:SetSolid( SOLID_VPHYSICS ) -- CHEESECAKE!	>:3
+
     Tracer = ents.Create( "env_spritetrail" )
     Tracer:SetKeyValue( "lifetime", "0.3" )
     Tracer:SetKeyValue( "startwidth", "32" )
@@ -17,9 +18,11 @@ function ENT:Initialize()
     Tracer:SetKeyValue( "rendermode", "5" )
     Tracer:SetKeyValue( "rendercolor", "255 255 255" )
     Tracer:SetPos( self:GetPos() )
-    Tracer:SetParent( self )
     Tracer:Spawn()
     Tracer:Activate()
+
+    self.Tracer = Tracer
+
     Glow = ents.Create( "env_sprite" )
     Glow:SetKeyValue( "model", "orangecore2.vmt" )
     Glow:SetKeyValue( "rendercolor", "37 138 210" )
@@ -31,6 +34,10 @@ function ENT:Initialize()
 end
 
 function ENT:Explode()
+
+    self.Tracer:SetPos( self:GetPos() )
+    SafeRemoveEntityDelayed( self.Tracer, 5 )
+
     -- damage equals 400 multiplied by two thirds of this turret's firing speed
     local baseDamage = 120
     local origin = self:GetPos()
@@ -66,7 +73,7 @@ function ENT:Think()
     trace.start = self:GetPos()
     trace.endpos = self:GetPos() + self.flightvector
     trace.filter = self
-    trace.mask = MASK_SHOT + MASK_WATER -- Trace for stuff that bullets would normally hit
+    trace.mask = bit.bxor( MASK_SHOT, MASK_WATER ) -- Trace for stuff that bullets would normally hit
     local tr = util.TraceLine( trace )
 
     if tr.Hit then
@@ -95,6 +102,8 @@ function ENT:Think()
     self.flightvector = self.flightvector + ( Vector( math.Rand( -0.1, 0.1 ), math.Rand( -0.1, 0.1 ), math.Rand( -0.1, 0.1 ) ) + Vector( 0, 0, math.Rand( 0, -0.32 ) ) )
     self:SetAngles( self.flightvector:Angle() )
     self:NextThink( CurTime() )
+
+    self.Tracer:SetPos( self:GetPos() ) -- use SetPos in think to prevent stupid bug where tracer jumps up to origin when unparented
 
     return true
 end

--- a/lua/entities/turret_bullets/shared.lua
+++ b/lua/entities/turret_bullets/shared.lua
@@ -32,7 +32,7 @@ function ENT:DoShot()
         end
 
         if IsValid( self.shootPos ) and SERVER then
-            local bulletDamage = 400 * self.ShotInterval -- ensuring dps of 400
+            local bulletDamage = 500 * self.ShotInterval -- ensuring dps of var
             self.shootPos:FireBullets( {
                 Num = 1,
                 Src = self.shootPos:GetPos() + self.shootPos:GetAngles():Forward() * 10,
@@ -55,7 +55,7 @@ function ENT:DoShot()
             } )
 
             --end
-            self:ApplyRecoil( 0.1, 1, 110000 )
+            self:ApplyRecoil( 0.1, 1, 140000 )
         end
 
         self.LastShot = CurTime()

--- a/lua/entities/turret_bullets2/shared.lua
+++ b/lua/entities/turret_bullets2/shared.lua
@@ -33,7 +33,7 @@ function ENT:DoShot()
         end
 
         if IsValid( self.shootPos ) and SERVER then
-            local fullDamage = 400 * self.ShotInterval -- ensuring dps of 400
+            local fullDamage = 500 * self.ShotInterval -- ensuring dps of var
             local bulletDamage = fullDamage * 0.66 --cutting up damage into two components
             local explosiveDamage = fullDamage * 0.33
             self.shootPos:FireBullets( {
@@ -69,7 +69,7 @@ function ENT:DoShot()
                 end
             } )
 
-            self:ApplyRecoil( 0.05, 1, -50000 )
+            self:ApplyRecoil( 0.05, 1, -70000 )
         end
 
         self.LastShot = CurTime()

--- a/lua/entities/turret_grenade/shared.lua
+++ b/lua/entities/turret_grenade/shared.lua
@@ -9,7 +9,7 @@ ENT.TurretFloatHeight = 3
 ENT.TurretModelOffset = Vector( 0, 0, 44 )
 ENT.TurretTurnMax = 0
 ENT.LastShot = 0
-ENT.ShotInterval = 1.2
+ENT.ShotInterval = 0.55
 ENT.longSpawnSetup = true
 
 ENT.angleInverse = -1
@@ -40,7 +40,7 @@ function ENT:DoShot()
             nade:SetOwner( self.Shooter )
             nade.flightvector = self:GetRight() * 35
             nade.Turret = self
-            self:ApplyRecoil( 0.1, 1, -5000 )
+            self:ApplyRecoil( 0.1, 1, -15000 )
         end
 
         self.LastShot = CurTime()

--- a/lua/entities/turret_rail/shared.lua
+++ b/lua/entities/turret_rail/shared.lua
@@ -9,7 +9,7 @@ ENT.TurretFloatHeight = 3
 ENT.TurretModelOffset = Vector( 0, 0, 44 )
 ENT.TurretTurnMax = 0
 ENT.LastShot = 0
-ENT.ShotInterval = 6.5
+ENT.ShotInterval = 10
 ENT.longSpawnSetup = true
 
 ENT.angleInverse = -1

--- a/lua/entities/turret_rail/shared.lua
+++ b/lua/entities/turret_rail/shared.lua
@@ -18,8 +18,8 @@ ENT.angleRotateAroundAxis = -90
 function ENT:easyForwardAng()
     if not IsValid( self.shootPos ) then return end
     if not IsValid( self.Shooter ) then return end
-    return self.shootPos:GetAngles() + Angle( self.Shooter:EyeAngles().p, -90, 0 )
 
+    return self.shootPos:GetAngles() + Angle( self.Shooter:EyeAngles().p, -90, 0 )
 end
 
 function ENT:DoShot()
@@ -30,22 +30,23 @@ function ENT:DoShot()
             local effectdata = EffectData()
             effectdata:SetStart( vPoint )
             effectdata:SetOrigin( vPoint )
-            effectdata:SetAngles( effectPosAng.Ang + Angle( 0, -90, 0 ) )
+            effectdata:SetAttachment( self.MuzzleAttachment )
             effectdata:SetEntity( self )
-            effectdata:SetScale( 2 )
-            util.Effect( "MuzzleEffect", effectdata )
+            effectdata:SetScale( 1 )
+            effectdata:SetRadius( 100 )
+            util.Effect( "GunshipMuzzleFlash", effectdata )
             self:EmitSound( self.ShotSound, 60, 100 ) -- hiss
             self:EmitSound( "npc/sniper/sniper1.wav", 155, 60 ) -- echo
             self:EmitSound( "weapons/ar2/npc_ar2_altfire.wav", 155, 60 ) -- deep thunk
 
-            FireGlow = ents.Create( "env_sprite" ) -- bright flash
-            FireGlow:SetKeyValue( "model", "orangecore2.vmt" )
-            FireGlow:SetKeyValue( "rendercolor", "37 138 255" )
-            FireGlow:SetKeyValue( "scale", "5" )
-            FireGlow:SetPos( self:GetPos() + ( self:easyForwardAng():Forward() * 50 ) )
-            SafeRemoveEntityDelayed( FireGlow, 0.05 )
-            FireGlow:Spawn()
-            FireGlow:Activate()
+            local fireGlow = ents.Create( "env_sprite" ) -- bright flash
+            fireGlow:SetKeyValue( "model", "orangecore2.vmt" )
+            fireGlow:SetKeyValue( "rendercolor", "37 138 255" )
+            fireGlow:SetKeyValue( "scale", "5" )
+            fireGlow:SetPos( self:GetPos() + ( self:easyForwardAng():Forward() * 50 ) )
+            SafeRemoveEntityDelayed( fireGlow, 0.05 )
+            fireGlow:Spawn()
+            fireGlow:Activate()
 
             util.ScreenShake( self:GetPos(), 10, 20, 0.1, 1000 ) -- strong shake when close
             util.ScreenShake( self:GetPos(), 1, 20, 0.8, 4000 ) -- weak shake when far

--- a/lua/entities/turret_rail/shared.lua
+++ b/lua/entities/turret_rail/shared.lua
@@ -15,6 +15,13 @@ ENT.longSpawnSetup = true
 ENT.angleInverse = -1
 ENT.angleRotateAroundAxis = -90
 
+function ENT:easyForwardAng()
+    if not IsValid( self.shootPos ) then return end
+    if not IsValid( self.Shooter ) then return end
+    return self.shootPos:GetAngles() + Angle( self.Shooter:EyeAngles().p, -90, 0 )
+
+end
+
 function ENT:DoShot()
     if self.LastShot + self.ShotInterval < CurTime() and self.doneSetup then
         if SERVER then
@@ -25,21 +32,34 @@ function ENT:DoShot()
             effectdata:SetOrigin( vPoint )
             effectdata:SetAngles( effectPosAng.Ang + Angle( 0, -90, 0 ) )
             effectdata:SetEntity( self )
-            effectdata:SetScale( 1 )
+            effectdata:SetScale( 2 )
             util.Effect( "MuzzleEffect", effectdata )
-            self:EmitSound( self.ShotSound, 50, 100 ) -- hiss
+            self:EmitSound( self.ShotSound, 60, 100 ) -- hiss
             self:EmitSound( "npc/sniper/sniper1.wav", 155, 60 ) -- echo
-            self:EmitSound( "weapons/ar2/npc_ar2_altfire.wav", 155, 30 ) -- deep thunk
+            self:EmitSound( "weapons/ar2/npc_ar2_altfire.wav", 155, 60 ) -- deep thunk
+
+            FireGlow = ents.Create( "env_sprite" ) -- bright flash
+            FireGlow:SetKeyValue( "model", "orangecore2.vmt" )
+            FireGlow:SetKeyValue( "rendercolor", "37 138 255" )
+            FireGlow:SetKeyValue( "scale", "5" )
+            FireGlow:SetPos( self:GetPos() + ( self:easyForwardAng():Forward() * 50 ) )
+            SafeRemoveEntityDelayed( FireGlow, 0.05 )
+            FireGlow:Spawn()
+            FireGlow:Activate()
+
+            util.ScreenShake( self:GetPos(), 10, 20, 0.1, 1000 ) -- strong shake when close
+            util.ScreenShake( self:GetPos(), 1, 20, 0.8, 4000 ) -- weak shake when far
+
         end
 
         if IsValid( self.shootPos ) and SERVER then
             local nade = ents.Create( "rail_shell" )
             nade:SetPos( self.shootPos:GetPos() + self.shootPos:GetUp() * 30 )
-            nade:SetAngles( self.shootPos:GetAngles() + Angle( self.Shooter:EyeAngles().p, -90, 0 ) )
+            nade:SetAngles( self:easyForwardAng() )
             nade:Spawn()
             nade:SetOwner( self.Shooter )
             nade.Turret = self
-            self:ApplyRecoil( 0.2, 1, -150000 )
+            self:ApplyRecoil( 0.2, 1, -1500000 )
         end
 
         self.LastShot = CurTime()


### PR DESCRIPTION
"This emplacement is setting up" message now appears when players try to fire, and a "no ammo" sound plays.
Made bullet turrets stronger.
Made grenade turret fire faster but the projectiles aren't as potent.

Made the rail-cannon deal more damage to whatever it directly hits.
To balance this, and the general strength of the turret. The rails' projectile trail is fixed, bigger, and lasts longer, it also takes roughly 1.8x as long to reload.