### PR TITLE
Properly pass argument

### DIFF
--- a/lua/entities/rail_shell/init.lua
+++ b/lua/entities/rail_shell/init.lua
@@ -106,7 +106,7 @@ function ENT:Think()
             end
         end
 
-        self:Explode()
+        self:Explode( tr )
     end
 
     if tr.Hit then


### PR DESCRIPTION
```
addons/emplacements/lua/entities/rail_shell/init.lua:50: attempt to index local 'tr' (a nil value)
   1.  __index - [C]:-1
    2.  Explode - addons/emplacements/lua/entities/rail_shell/init.lua:50
     3.  unknown - addons/emplacements/lua/entities/rail_shell/init.lua:109
```