### PR TITLE
Rebalance and rework emplacements

### DIFF
--- a/lua/entities/rail_shell/init.lua
+++ b/lua/entities/rail_shell/init.lua
@@ -36,13 +36,13 @@ function ENT:Initialize()
 end
 
 -- damage equals 400 multipled by a bit less than the firing interval
-local baseDamage = 1188
+local baseDamage = 400 --1188
 
 function ENT:Explode( tr )
     local effectDir = -self:GetForward() --have the effect "point" towards the turret, makes it very clear where you are being shot from
 
-    local tightDamage = baseDamage * 0.66 -- dividing up the damage into 2 components since we have 2 explosions w/ different distances
-    local wideDamage  = baseDamage * 0.33
+    local tightDamage = baseDamage * 0.33 -- dividing up the damage into 2 components since we have 2 explosions w/ different distances
+    local wideDamage  = baseDamage * 0.66
 
     local owner = IsValid( self:GetOwner() ) and self:GetOwner()
     local attacker = owner or self.Turret or self

--- a/lua/entities/turret_40mm_frag/init.lua
+++ b/lua/entities/turret_40mm_frag/init.lua
@@ -34,7 +34,7 @@ function ENT:Initialize()
 end
 
 -- damage equals 400 multiplied by 75% of this turret's firing speed
-local baseDamage = 150
+local baseDamage = 100
 
 function ENT:Explode()
     local origin = self:GetPos()
@@ -52,9 +52,9 @@ function ENT:Explode()
     effectdata:SetNormal( -normal ) -- Direction of Impact
     effectdata:SetStart( normal ) -- Direction of Round
     effectdata:SetEntity( self ) -- Who done it?
-    effectdata:SetScale( 0.8 ) -- Size of explosion
+    effectdata:SetScale( 1.5 ) -- Size of explosion
     effectdata:SetRadius( concrete ) -- Texture of Impact
-    effectdata:SetMagnitude( 16 ) -- Length of explosion trails
+    effectdata:SetMagnitude( 64 ) -- Length of explosion trails
     util.Effect( "gdca_airburst_t", effectdata )
     util.ScreenShake( origin, 10, 5, 1, 1300 )
     util.Decal( "Scorch", origin + normal, origin - normal )

--- a/lua/entities/turret_bullets/shared.lua
+++ b/lua/entities/turret_bullets/shared.lua
@@ -60,7 +60,7 @@ function ENT:Think()
 
         if heatPenalty > 0 then
             local smokeEffect = EffectData()
-            smokeEffect:SetOrigin( self:LocalToWorld( Vector( 0,35,14 ) ) )
+            smokeEffect:SetOrigin( self:LocalToWorld( Vector( 0,35,22 ) ) )
             smokeEffect:SetNormal( self:GetRight() )
             smokeEffect:SetScale( 20 * (heatPenalty+1) )
 

--- a/lua/entities/turret_bullets/shared.lua
+++ b/lua/entities/turret_bullets/shared.lua
@@ -25,7 +25,7 @@ local COOLING_TIME = 4
 
 -- How long it takes to spin up
 local SPINUP_TIME = 3
-local SPINDOWN_TIME = 5
+local SPINDOWN_TIME = 6
 
 local MIN_SHOT_INTERVAL = 0.15
 local MAX_SHOT_INTERVAL = 0.03
@@ -38,12 +38,14 @@ function ENT:Initialize()
         self.Heat = 0
         self.SpinUp = 0
         self.ShotInterval = MIN_SHOT_INTERVAL
+        self.RampUpSound = CreateSound( self, "vehicles/airboat/fan_motor_fullthrottle_loop1.wav" )
+        self.RampUpSound:PlayEx( 0, 0 )
     end
 end
 
 
 function ENT:Think()
-    BaseClass.Think( self )
+    local r = BaseClass.Think( self )
     
     if SERVER then
         if self.Firing then
@@ -61,16 +63,18 @@ function ENT:Think()
             smokeEffect:SetOrigin( self:LocalToWorld( Vector( 0,35,14 ) ) )
             smokeEffect:SetNormal( self:GetRight() )
             smokeEffect:SetScale( 20 * (heatPenalty+1) )
-            smokeEffect:SetScale( 40000 ) -- usain bolt speed
 
             util.Effect( "ElectricSpark", smokeEffect )
         end
 
-        self.ShotInterval = Lerp(self.SpinUp - heatPenalty, MIN_SHOT_INTERVAL, MAX_SHOT_INTERVAL)
-        Entity(1):ChatPrint("Heat: " .. self.Heat .. "\nSpin: " .. self.SpinUp)
+        local totalSpinUp = self.SpinUp - heatPenalty
+        self.RampUpSound:ChangeVolume( totalSpinUp*3 )
+        self.RampUpSound:ChangePitch( 50 + totalSpinUp*100)
+
+        self.ShotInterval = Lerp(totalSpinUp, MIN_SHOT_INTERVAL, MAX_SHOT_INTERVAL)
     end
 
-    return true
+    return r
 end
 
 

--- a/lua/entities/turret_bullets/shared.lua
+++ b/lua/entities/turret_bullets/shared.lua
@@ -28,7 +28,7 @@ local SPINUP_TIME = 3
 local SPINDOWN_TIME = 6
 
 local MIN_SHOT_INTERVAL = 0.15
-local MAX_SHOT_INTERVAL = 0.03
+local MAX_SHOT_INTERVAL = 0.0225
 
 
 function ENT:Initialize()
@@ -68,8 +68,8 @@ function ENT:Think()
         end
 
         local totalSpinUp = self.SpinUp - heatPenalty
-        self.RampUpSound:ChangeVolume( totalSpinUp*3 )
-        self.RampUpSound:ChangePitch( 50 + totalSpinUp*100 )
+        self.RampUpSound:ChangeVolume( self.SpinUp*3 )
+        self.RampUpSound:ChangePitch( 50 + self.SpinUp*100 )
 
         self.ShotInterval = Lerp( totalSpinUp, MIN_SHOT_INTERVAL, MAX_SHOT_INTERVAL )
     end
@@ -96,7 +96,7 @@ function ENT:DoShot()
         end
 
         if IsValid( self.shootPos ) and SERVER then
-            local bulletDamage = 1250 * MAX_SHOT_INTERVAL -- ensuring dps of var
+            local bulletDamage = 1400 * MAX_SHOT_INTERVAL -- ensuring dps of var
             self.shootPos:FireBullets( {
                 Num = 1,
                 Src = self.shootPos:GetPos() + self.shootPos:GetAngles():Forward() * 10,

--- a/lua/entities/turret_bullets/shared.lua
+++ b/lua/entities/turret_bullets/shared.lua
@@ -69,9 +69,9 @@ function ENT:Think()
 
         local totalSpinUp = self.SpinUp - heatPenalty
         self.RampUpSound:ChangeVolume( totalSpinUp*3 )
-        self.RampUpSound:ChangePitch( 50 + totalSpinUp*100)
+        self.RampUpSound:ChangePitch( 50 + totalSpinUp*100 )
 
-        self.ShotInterval = Lerp(totalSpinUp, MIN_SHOT_INTERVAL, MAX_SHOT_INTERVAL)
+        self.ShotInterval = Lerp( totalSpinUp, MIN_SHOT_INTERVAL, MAX_SHOT_INTERVAL )
     end
 
     return r
@@ -96,7 +96,7 @@ function ENT:DoShot()
         end
 
         if IsValid( self.shootPos ) and SERVER then
-            local bulletDamage = 1250 * self.ShotInterval -- ensuring dps of var
+            local bulletDamage = 1250 * MAX_SHOT_INTERVAL -- ensuring dps of var
             self.shootPos:FireBullets( {
                 Num = 1,
                 Src = self.shootPos:GetPos() + self.shootPos:GetAngles():Forward() * 10,

--- a/lua/entities/turret_bullets/shared.lua
+++ b/lua/entities/turret_bullets/shared.lua
@@ -78,6 +78,15 @@ function ENT:Think()
 end
 
 
+function ENT:OnRemove()
+    if SERVER then
+        self.RampUpSound:Stop()
+        self.RampUpSound = nil
+    end
+
+    BaseClass.OnRemove( self )
+end
+
 
 function ENT:DoShot()
     if self.lastShot + self.ShotInterval < CurTime() and self.doneSetup then

--- a/lua/entities/turret_bullets/shared.lua
+++ b/lua/entities/turret_bullets/shared.lua
@@ -33,14 +33,13 @@ local MAX_SHOT_INTERVAL = 0.0225
 
 function ENT:Initialize()
     BaseClass.Initialize( self )
-
-    if SERVER then
-        self.Heat = 0
-        self.SpinUp = 0
-        self.ShotInterval = MIN_SHOT_INTERVAL
-        self.RampUpSound = CreateSound( self, "vehicles/airboat/fan_motor_fullthrottle_loop1.wav" )
-        self.RampUpSound:PlayEx( 0, 0 )
-    end
+    if not SERVER then return end
+    
+    self.Heat = 0
+    self.SpinUp = 0
+    self.ShotInterval = MIN_SHOT_INTERVAL
+    self.RampUpSound = CreateSound( self, "vehicles/airboat/fan_motor_fullthrottle_loop1.wav" )
+    self.RampUpSound:PlayEx( 0, 0 )
 end
 
 

--- a/lua/entities/turret_bullets2/shared.lua
+++ b/lua/entities/turret_bullets2/shared.lua
@@ -42,7 +42,7 @@ function ENT:DoShot()
                 Num = 1,
                 Src = self.shootPos:GetPos() + self.shootPos:GetAngles():Up() * 10,
                 Dir = self:EasyForwardAng():Forward() * 1,
-                Spread = Vector( 0.005, 0.005, 0 ),
+                Spread = Vector( 0.01, 0.01, 0 ),
                 Tracer = 0,
                 Force = bulletDamage,
                 Damage = bulletDamage,

--- a/lua/entities/turret_bullets2/shared.lua
+++ b/lua/entities/turret_bullets2/shared.lua
@@ -1,7 +1,7 @@
 ENT.Type = "anim"
 ENT.Base = "emplacements_turret_base"
 ENT.Category = "Emplacements"
-ENT.PrintName = "14mm Turret"
+ENT.PrintName = "Anti-Material Turret"
 ENT.Author = "Wolly/BOT_09"
 ENT.Spawnable = true
 ENT.AdminSpawnable = false
@@ -35,9 +35,9 @@ function ENT:DoShot()
         end
 
         if IsValid( self.shootPos ) and SERVER then
-            local fullDamage = 650 * self.ShotInterval -- ensuring dps of var
-            local bulletDamage = fullDamage * 0.66 --cutting up damage into two components
-            local explosiveDamage = fullDamage * 0.33
+            local fullDamage = 320 * self.ShotInterval -- ensuring dps of var
+            local bulletDamage = fullDamage * 0.5 --cutting up damage into two components
+            local explosiveDamage = fullDamage * 0.5
             self.shootPos:FireBullets( {
                 Num = 1,
                 Src = self.shootPos:GetPos() + self.shootPos:GetAngles():Up() * 10,

--- a/lua/entities/turret_grenade/shared.lua
+++ b/lua/entities/turret_grenade/shared.lua
@@ -15,7 +15,7 @@ ENT.DoCrosshair = false
 
 ENT.angleInverse = -1
 
-local SPREAD = 0.15
+local SPREAD = 0.1
 local MUZZLE_VEL = 45
 
 function ENT:DoShot()

--- a/lua/entities/turret_grenade/shared.lua
+++ b/lua/entities/turret_grenade/shared.lua
@@ -15,6 +15,9 @@ ENT.DoCrosshair = false
 
 ENT.angleInverse = -1
 
+local SPREAD = 0.15
+local MUZZLE_VEL = 45
+
 function ENT:DoShot()
     if self.lastShot + self.ShotInterval < CurTime() and self.doneSetup then
         if SERVER then
@@ -39,7 +42,7 @@ function ENT:DoShot()
             nade:SetAngles( self:EasyForwardAng() )
             nade:Spawn()
             nade:SetOwner( self:GetShooter() )
-            nade.flightvector = self:GetRight() * 35
+            nade.flightvector = self:GetPhysicsObject():LocalToWorldVector( Vector( ( math.random()-0.5 )*SPREAD, -1, ( math.random()-0.5 )*SPREAD ) ):GetNormalized() * MUZZLE_VEL
             nade.Turret = self
             self:ApplyRecoil( 0.1, 1, -1500 )
         end

--- a/lua/entities/turret_grenade/shared.lua
+++ b/lua/entities/turret_grenade/shared.lua
@@ -1,7 +1,7 @@
 ENT.Type = "anim"
 ENT.Base = "emplacements_turret_base"
 ENT.Category = "Emplacements"
-ENT.PrintName = "40MM HE Turret"
+ENT.PrintName = "40mm Grenade Turret"
 ENT.Author = "Wolly/BOT_09"
 ENT.Spawnable = true
 ENT.AdminSpawnable = false


### PR DESCRIPTION
Grenade Turret:
- name "40mm HE Turret" -> "40mm Grenade Turret"
- spread 0 -> 0.15
- damage 150 -> 100
- explosion effect size now reflects the actual blast radius better
- muzzle velocity 35 -> 45

Railcannon Turret:
- made damage dropoff from the blast radius much more aggressive (internally: swapped "wide" and "tight" explosion multipliers to 0.33 and 0.66 respectively)
- damage 1188 -> 400

14mm Turret:
- name "14mm Turret" -> "Anti-Material Turret"
- explosive to bullet damage ratio 0.66:0.33 -> 0.5:0.5
- damage 260 -> 128
- spread 0.005 -> 0.01

Machinegun Turret:
- name "7.62x39mm Turret" -> "Machinegun Turret"
- firerate now ramps up overtime the longer you hold it down (3s spinup time, 6s spindown time)
- added a heat value, if this gets too high the gun stops shooting as fast and starts smoking (7s overheat time, 4s cooldown time)
- Fire interval 0.03 -> 0.0225
- Damage 37.5 -> 31.5
- (^ DPS 1250 -> 1400)
- added a firing sound akin to a minigun