### PR TITLE
Buff a bunch of emplacements

### DIFF
--- a/lua/entities/emplacements_turret_base/init.lua
+++ b/lua/entities/emplacements_turret_base/init.lua
@@ -88,6 +88,7 @@ function ENT:CreateEmplacement()
     shootPos:SetNoDraw( false )
     shootPos:DrawShadow( false )
     shootPos.EmplacementTurret = self
+    shootPos.PropDamageMultiplier = self.PropDamageMultiplier
     --shootPos:SetColor(Color(0,0,0,0))
     self:SetDTEntity( 1, shootPos )
 end

--- a/lua/entities/emplacements_turret_base/init.lua
+++ b/lua/entities/emplacements_turret_base/init.lua
@@ -68,11 +68,17 @@ function ENT:CreateEmplacement()
     turretBase:SetAngles( self:GetAngles() + Angle( 0, self.turretInitialAngle, 0 ) )
     turretBase:SetPos( self:GetPos() - Vector( 0, 0, 0 ) )
     turretBase:Spawn()
+    turretBase.DoNotDuplicate = true
+    
     local obj = turretBase:GetPhysicsObject()
     if IsValid( obj ) then
         obj:SetMass( self.BaseMass )
-
     end
+
+    if CPPI then
+        turretBase:CPPISetOwner( self:CPPIGetOwner() )
+    end
+
     self.turretBase = turretBase
     constraint.NoCollide( self.turretBase, self, 0, 0 )
 

--- a/lua/entities/rail_shell/init.lua
+++ b/lua/entities/rail_shell/init.lua
@@ -23,8 +23,7 @@ function ENT:Initialize()
     tracer:SetPos( self:GetPos() )
     tracer:Spawn()
     tracer:Activate()
-
-    self.PropDamageMultiplier = 0.75
+    
     self.Tracer = tracer
 
     local glow = ents.Create( "env_sprite" )

--- a/lua/entities/rail_shell/init.lua
+++ b/lua/entities/rail_shell/init.lua
@@ -4,6 +4,7 @@ include( "shared.lua" )
 
 local IsValid = IsValid
 
+
 function ENT:Initialize()
     self.flightvector = self:GetForward() * 300
     self.timeleft = CurTime() + 5
@@ -23,6 +24,7 @@ function ENT:Initialize()
     tracer:Spawn()
     tracer:Activate()
 
+    self.PropDamageMultiplier = 0.75
     self.Tracer = tracer
 
     local glow = ents.Create( "env_sprite" )
@@ -36,13 +38,13 @@ function ENT:Initialize()
 end
 
 -- damage equals 400 multipled by a bit less than the firing interval
-local baseDamage = 400 --1188
+local baseDamage = 600 --1188
 
 function ENT:Explode( tr )
     local effectDir = -self:GetForward() --have the effect "point" towards the turret, makes it very clear where you are being shot from
 
-    local tightDamage = baseDamage * 0.33 -- dividing up the damage into 2 components since we have 2 explosions w/ different distances
-    local wideDamage  = baseDamage * 0.66
+    local tightDamage = baseDamage * 0.5 -- dividing up the damage into 2 components since we have 2 explosions w/ different distances
+    local wideDamage  = baseDamage * 0.5
 
     local owner = IsValid( self:GetOwner() ) and self:GetOwner()
     local attacker = owner or self.Turret or self

--- a/lua/entities/turret_bullets/shared.lua
+++ b/lua/entities/turret_bullets/shared.lua
@@ -66,12 +66,13 @@ function ENT:RunHeatHandler()
         smokeEffect:SetOrigin( self:LocalToWorld( Vector( 0,35,22 ) ) )
         smokeEffect:SetNormal( self:GetRight() )
         smokeEffect:SetScale( 20 * (heatPenalty+1) )
+        smokeEffect:SetMagnitude( 0 )
 
         util.Effect( "ElectricSpark", smokeEffect )
     end
 
     local totalSpinUp = self.SpinUp - heatPenalty
-    self.RampUpSound:ChangeVolume( self.SpinUp*3 )
+    self.RampUpSound:ChangeVolume( self.SpinUp )
     self.RampUpSound:ChangePitch( 50 + self.SpinUp*100 )
 
     self.ShotInterval = Lerp( totalSpinUp, MIN_SHOT_INTERVAL, MAX_SHOT_INTERVAL )

--- a/lua/entities/turret_bullets/shared.lua
+++ b/lua/entities/turret_bullets/shared.lua
@@ -123,15 +123,18 @@ function ENT:DoShot()
                 Force = bulletDamage,
                 Damage = bulletDamage,
                 Attacker = self:GetShooter(),
-                Callback = function( _, trace )
+                Callback = function( _, trace, dmgInfo )
+                
+                    if IsValid(trace.Entity) and trace.Entity:IsVehicle() then
+                        dmgInfo:ScaleDamage( 0.5 )
+                    end
 
-                local tracerEffect = EffectData()
-                tracerEffect:SetStart( self.shootPos:GetPos() )
-                tracerEffect:SetOrigin( trace.HitPos )
-                tracerEffect:SetScale( 6000 ) --pretty fast
+                    local tracerEffect = EffectData()
+                    tracerEffect:SetStart( self.shootPos:GetPos() )
+                    tracerEffect:SetOrigin( trace.HitPos )
+                    tracerEffect:SetScale( 6000 ) --pretty fast
 
-                util.Effect( "StriderTracer", tracerEffect ) -- big but not too big effect
-
+                    util.Effect( "StriderTracer", tracerEffect ) -- big but not too big effect
                 end
             } )
 

--- a/lua/entities/turret_bullets/shared.lua
+++ b/lua/entities/turret_bullets/shared.lua
@@ -14,6 +14,8 @@ ENT.LongSpawnSetup = false
 
 ENT.angleInverse = 1
 
+ENT.PropDamageMultiplier = 0.5
+
 
 DEFINE_BASECLASS( "emplacements_turret_base" )
 

--- a/lua/entities/turret_bullets/shared.lua
+++ b/lua/entities/turret_bullets/shared.lua
@@ -22,15 +22,15 @@ DEFINE_BASECLASS( "emplacements_turret_base" )
 
 
 -- The rate heat generates per second at peak firerate
-local OVERHEAT_TIME = 7
-local COOLING_TIME = 4
+local OVERHEAT_TIME = 14
+local COOLING_TIME = 7
 
 -- How long it takes to spin up
 local SPINUP_TIME = 3
 local SPINDOWN_TIME = 6
 
 local MIN_SHOT_INTERVAL = 0.15
-local MAX_SHOT_INTERVAL = 0.0225
+local MAX_SHOT_INTERVAL = 0.02
 
 
 function ENT:Initialize()
@@ -111,7 +111,9 @@ function ENT:DoShot()
         end
 
         if IsValid( self.shootPos ) and SERVER then
-            local bulletDamage = 1400 * MAX_SHOT_INTERVAL -- ensuring dps of var
+            local bulletDamage = 40
+            self:GetShooter():LagCompensation(true)
+
             self.shootPos:FireBullets( {
                 Num = 1,
                 Src = self.shootPos:GetPos() + self.shootPos:GetAngles():Forward() * 10,
@@ -126,13 +128,15 @@ function ENT:DoShot()
                 local tracerEffect = EffectData()
                 tracerEffect:SetStart( self.shootPos:GetPos() )
                 tracerEffect:SetOrigin( trace.HitPos )
-                tracerEffect:SetScale( 8000 ) --pretty fast
+                tracerEffect:SetScale( 6000 ) --pretty fast
 
                 util.Effect( "StriderTracer", tracerEffect ) -- big but not too big effect
 
                 end
             } )
 
+            self:GetShooter():LagCompensation(false)
+            
             --end
             self:ApplyRecoil( 0.1, 1, 1000 )
         end

--- a/lua/entities/turret_bullets/shared.lua
+++ b/lua/entities/turret_bullets/shared.lua
@@ -23,7 +23,7 @@ DEFINE_BASECLASS( "emplacements_turret_base" )
 
 -- The rate heat generates per second at peak firerate
 local OVERHEAT_TIME = 14
-local COOLING_TIME = 7
+local COOLING_TIME = 4
 
 -- How long it takes to spin up
 local SPINUP_TIME = 3
@@ -52,10 +52,10 @@ end
 
 function ENT:RunHeatHandler()
     if self.Firing then
-        self:SetHeat( math.min( self:GetHeat() + FrameTime() / OVERHEAT_TIME, 1 ) )
+        self:SetHeat( math.min( self:GetHeat() + FrameTime() / OVERHEAT_TIME * self.SpinUp, 1 ) )
         self.SpinUp = math.min( self.SpinUp + FrameTime() / SPINUP_TIME, 1 )
     else
-        self:SetHeat( math.max( self:GetHeat() - FrameTime() / COOLING_TIME, 0 ) )
+        self:SetHeat( math.max( self:GetHeat() - FrameTime() / COOLING_TIME * (1-self.SpinUp), 0 ) )
         self.SpinUp = math.max( self.SpinUp - FrameTime() / SPINDOWN_TIME, 0 )
     end
 

--- a/lua/entities/turret_bullets/shared.lua
+++ b/lua/entities/turret_bullets/shared.lua
@@ -14,7 +14,7 @@ ENT.LongSpawnSetup = false
 
 ENT.angleInverse = 1
 
-ENT.PropDamageMultiplier = 0.5
+ENT.PropDamageMultiplier = 0.8
 
 
 DEFINE_BASECLASS( "emplacements_turret_base" )

--- a/lua/entities/turret_bullets/shared.lua
+++ b/lua/entities/turret_bullets/shared.lua
@@ -14,7 +14,7 @@ ENT.LongSpawnSetup = false
 
 ENT.angleInverse = 1
 
-ENT.PropDamageMultiplier = 0.8
+ENT.PropDamageMultiplier = 0.5
 
 
 DEFINE_BASECLASS( "emplacements_turret_base" )

--- a/lua/entities/turret_bullets2/shared.lua
+++ b/lua/entities/turret_bullets2/shared.lua
@@ -35,9 +35,12 @@ function ENT:DoShot()
         end
 
         if IsValid( self.shootPos ) and SERVER then
-            local fullDamage = 320 * self.ShotInterval -- ensuring dps of var
-            local bulletDamage = fullDamage * 0.5 --cutting up damage into two components
-            local explosiveDamage = fullDamage * 0.5
+            local fullDamage = 140
+            local bulletDamage = fullDamage * 0.67 --cutting up damage into two components
+            local explosiveDamage = fullDamage * 0.33
+
+            self:GetShooter():LagCompensation( true )
+
             self.shootPos:FireBullets( {
                 Num = 1,
                 Src = self.shootPos:GetPos() + self.shootPos:GetAngles():Up() * 10,
@@ -47,7 +50,7 @@ function ENT:DoShot()
                 Force = bulletDamage,
                 Damage = bulletDamage,
                 Attacker = self:GetShooter(),
-                Callback = function( _, trace )
+                Callback = function( _, trace, dmgInfo )
                     local concrete = 67 -- has to be concrete else errors are spammed
                     local tracerEffect = EffectData()
                     tracerEffect:SetStart( self.shootPos:GetPos() )
@@ -56,6 +59,11 @@ function ENT:DoShot()
 
                     util.Effect( "AirboatGunHeavyTracer", tracerEffect ) -- BIG effect
                     if trace.HitSky then return end
+
+                    if IsValid(trace.Entity) and trace.Entity:IsVehicle() then
+                        dmgInfo:ScaleDamage( 0.35 )
+                        explosiveDamage = explosiveDamage * 0.35
+                    end
 
                     local inflictor = self:GetShooter() or self
                     util.BlastDamage( self, inflictor, trace.HitPos, 100, explosiveDamage ) -- explosion for anti armour power
@@ -70,7 +78,9 @@ function ENT:DoShot()
 
                 end
             } )
-
+            
+            self:GetShooter():LagCompensation( false )
+            
             self:ApplyRecoil( 0.05, 1, -7000 )
         end
 

--- a/lua/entities/turret_bullets2/shared.lua
+++ b/lua/entities/turret_bullets2/shared.lua
@@ -14,6 +14,8 @@ ENT.LongSpawnSetup = true
 
 ENT.angleInverse = -1
 
+ENT.PropDamageMultiplier = 0.75
+
 function ENT:DoShot()
     if self.lastShot + self.ShotInterval < CurTime() and self.doneSetup then
         if SERVER then
@@ -35,7 +37,7 @@ function ENT:DoShot()
         end
 
         if IsValid( self.shootPos ) and SERVER then
-            local fullDamage = 140
+            local fullDamage = 180
             local bulletDamage = fullDamage * 0.67 --cutting up damage into two components
             local explosiveDamage = fullDamage * 0.33
 


### PR DESCRIPTION
Machinegun:
- overheat time 7s -> 14s
- will no longer cool down as fast while revved up
- max shot interval 0.0225 -> 0.02
- damage per shot 31.5 -> 40
- damage conversion multiplier 1x -> 0.8x
- shots are now lag compensated
- vehicle damage multiplier 1x -> 0.5x
- added a visual indicator for heat

Railgun:
- reverted damage falloff adjustments
- damage 400 -> 600

Anti-Material:
- damage 128 -> 180
- shots are now lag compensated
- vehicle damage multiplier 1x -> 0.35x
- prop damage multiplier 1x -> 0.75x